### PR TITLE
feat: add validation parameters method to client

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -2,7 +2,11 @@ import dotenv from 'dotenv'
 import moment from 'moment'
 import { PluggyClient } from 'pluggy-sdk'
 
-import { sleep, PLUGGY_BANK_CREDENTIALS, PLUGGY_BANK_CONNECTOR } from './utils'
+import {
+  sleep,
+  PLUGGY_BANK_CREDENTIALS,
+  PLUGGY_BANK_CONNECTOR as PLUGGY_BANK_CONNECTOR_ID,
+} from './utils'
 
 dotenv.config()
 
@@ -25,14 +29,21 @@ void (async function(): Promise<void> {
   })
 
   // View credentials
-  const connector = await client.fetchConnector(PLUGGY_BANK_CONNECTOR)
+  const connector = await client.fetchConnector(PLUGGY_BANK_CONNECTOR_ID)
   console.log(`We are going to connect with ${connector.name}`)
 
   console.log('We will send the parameters that are OK.')
   console.log(PLUGGY_BANK_CREDENTIALS)
 
+  // Validate connector parameters
+  const validation = await client.validateParameters(
+    PLUGGY_BANK_CONNECTOR_ID,
+    PLUGGY_BANK_CREDENTIALS
+  )
+  console.log(`Connector parameter validation: `, validation)
+
   // Create a connection
-  let item = await client.createItem(PLUGGY_BANK_CONNECTOR, PLUGGY_BANK_CREDENTIALS)
+  let item = await client.createItem(PLUGGY_BANK_CONNECTOR_ID, PLUGGY_BANK_CREDENTIALS)
 
   while (!['LOGIN_ERROR', 'OUTDATED', 'UPDATED'].includes(item.status)) {
     console.log(`Item ${item.id} is syncing with the institution`)

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ import {
   CreateItemOptions,
 } from './types'
 import { transformItem, transformPageResponse, transformTransaction } from './transforms'
+import { ValidationResult } from './types/validation'
 
 /**
  * Creates a new client instance for interacting with Pluggy API
@@ -63,6 +64,19 @@ export class PluggyClient extends BaseApi {
    */
   async fetchItem(id: string): Promise<Item> {
     return this.createGetRequest(`items/${id}`, null, transformItem)
+  }
+
+  /**
+   * Check that connector parameters are valid
+   * @param id The Connector ID
+   * @param parameters A map of name and value for the credentials to be validated
+   * @returns {ValidationResult} an object with the info of which parameters are wrong
+   */
+  async validateParameters(
+    id: number,
+    parameters: Record<string, string>
+  ): Promise<ValidationResult> {
+    return this.createPostRequest(`connectors/${id}/validate`, null, parameters)
   }
 
   /**

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -1,0 +1,10 @@
+export type ValidationError = {
+  code: string
+  message: string
+  parameter: string
+}
+
+export type ValidationResult = {
+  parameters: Record<string, string>
+  errors: ValidationError[]
+}


### PR DESCRIPTION
# What? 

Create a `client.validateParameters(connectorId, parameters)` function that returns errors if parameters are invalid

# Why?

So developers can show error/warning or fallback in case parameters are wrong BEFORE creating an item