### PR TITLE
Sometimes it does not find the account for sandbox

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -145,7 +145,12 @@ export class PluggyClient extends BaseApi {
    * @returns {PageResponse<Account>} paged response of accounts
    */
   async fetchAccounts(itemId: string, type?: AccountType): Promise<PageResponse<Account>> {
-    return await this.createGetRequest('accounts', { itemId, type })
+    const options: Parameters = { itemId }
+    if (type) {
+      options.type = type
+    }
+
+    return await this.createGetRequest('accounts', options)
   }
 
   /**


### PR DESCRIPTION
While testing Actual budget, the sdk was not finding the sandbox account linked to the app.
This fixed