### PR TITLE
fix(test): rename --testPathPattern to --testPathPatterns for Jest 30

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "test": "jest --testPathIgnorePatterns=tests/integration.test.ts",
-    "test:integration": "jest --testPathPattern=integration --runInBand",
+    "test:integration": "jest --testPathPatterns=integration --runInBand",
     "build": "tsc -p tsconfig.build.json",
     "prepare": "pnpm build",
     "prettier-fix": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
## Summary

Unblocks the **Run Integration Tests** step in `release.yml`, which started failing on the merge of #160 with:

\`\`\`
Option "testPathPattern" was replaced by "--testPathPatterns".
"--testPathPatterns" is only available as a command-line option.
\`\`\`

Jest 30 dropped the singular `--testPathPattern` flag in favour of the plural `--testPathPatterns`. The `test:integration` script still used the old form.

The sibling `test` script uses `--testPathIgnorePatterns`, which was already plural in Jest 29, so it is not affected.

## Test plan

- [ ] CI release workflow's `Run Integration Tests` step passes once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)