### PR TITLE
ci: publish to npm via OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -40,5 +46,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm exec semantic-release

--- a/package.json
+++ b/package.json
@@ -83,7 +83,12 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
+      [
+        "@semantic-release/npm",
+        {
+          "provenance": true
+        }
+      ],
       "@semantic-release/github",
       [
         "@semantic-release/git",


### PR DESCRIPTION
## Summary
- Switches the release workflow from a long-lived `NPM_TOKEN` to short-lived OIDC tokens that npm validates against the Trusted Publisher config on npmjs.com.
- Enables `--provenance` so every published version ships a signed attestation linking the tarball to the commit, workflow file, and run that produced it (visible as a verified badge on npmjs.com).
- Binds the job to the existing `release` GitHub Environment so the manual-approval gate keeps applying.

## Changes
- `.github/workflows/release.yml`
  - `environment: release` on the job.
  - `permissions:` block with `id-token: write` (required for OIDC), plus `contents: write`, `issues: write`, `pull-requests: write` that semantic-release already needs to push the version bump, tag, and GitHub release.
  - Dropped the `NPM_TOKEN` env var — `@semantic-release/npm@13` prefers `NPM_TOKEN` over OIDC when both are present, so it has to go for OIDC to actually kick in.
- `package.json`
  - `@semantic-release/npm` plugin entry expanded to `[name, { provenance: true }]`.

## Test plan
- [ ] Confirm Trusted Publisher entry exists on npmjs.com with the values above.
- [ ] Merge to `master` and watch the `Release` workflow run.
- [ ] Verify the published version on npmjs.com shows the "Provenance" badge with this repo + workflow + commit SHA.
- [ ] After a successful release, delete the `NPM_TOKEN` repo secret.
