### PR TITLE
ci: push release commit via GitHub App token to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,17 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_SECRET }}
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
@@ -45,5 +52,5 @@ jobs:
         run: pnpm test:integration
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm exec semantic-release


### PR DESCRIPTION
## Summary
Follow-up to #162. semantic-release needs to push the version bump commit and tag back to `master`, but the default `GITHUB_TOKEN` cannot push to a protected branch. This switches the workflow to mint a short-lived token from a GitHub App (configured with bypass on `master`) and uses it for both the checkout (so `git push` runs as the App) and for the `@semantic-release/github` API calls.
