### PR TITLE
ci: enforce Conventional Commits format on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+name: PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Validate Conventional Commits title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            chore
+            docs
+            style
+            refactor
+            test
+            build
+            ci
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary
Adds a new workflow that validates PR titles against the Conventional Commits spec. The repo squash-merges PRs, so each PR title becomes the commit on `master` that semantic-release parses to decide the next version bump — without this gate, a non-conforming title produces a commit semantic-release ignores (no release at all) or misclassifies.

## How it works
- New workflow: `.github/workflows/pr-title.yml`
- Uses [`amannn/action-semantic-pull-request@v6.1.1`](https://github.com/amannn/action-semantic-pull-request) — the de-facto standard for this.
- Triggers on `pull_request` (`opened`, `edited`, `reopened`, `synchronize`) targeting `master`. Re-runs whenever the title is edited so contributors can fix it in place.
- Permissions: `pull-requests: read` only.

## Config
Allowed types (matches semantic-release's Angular preset plus common no-release types):
- Releases a version: `feat`, `fix`, `perf`
- No release (still allowed): `chore`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `revert`

Scope is optional (`fix:` and `fix(test):` both pass).

## Required follow-up (outside this PR)
The action only **reports** a status check called `Validate Conventional Commits title`. To actually **block** merges of non-conforming PRs, that check needs to be added to `master`'s branch protection rule as a **required status check**. After this PR merges, open one test PR with a bad title to make the check appear in the list, then add it.

## Test plan
- [ ] Merge this PR.
- [ ] Open a test PR with title `bad title` — the check should fail.
- [ ] Edit the title to `chore: test pr title check` — the check should re-run and pass.
- [ ] Add `Validate Conventional Commits title` to `master` branch protection's required checks.
- [ ] Close the test PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)