### PR TITLE
docs: migrate transactions examples and tests off deprecated fetchTransactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,23 +86,40 @@ await client.updateItemMFA(item.id, {
 
 ### Accounts and transactions (with pagination)
 
-Most list endpoints support filters/pagination via an `options` object.
+Transactions use **cursor-based pagination** against `GET /v2/transactions`. The SDK exposes two helpers:
+
+- `fetchTransactionsCursor(accountId, options)` — fetch a single page and the cursor to the next one.
+- `fetchAllTransactions(accountId, options)` — iterate through every page and return the full list.
 
 ```ts
 const accounts = await client.fetchAccounts(item.id)
+const account = accounts.results[0]
 
-const firstPage = await client.fetchTransactions({
-  itemId: item.id,
-  page: 1,
-  pageSize: 20,
+// Single page (returns { results, next })
+const page = await client.fetchTransactionsCursor(account.id, {
+  dateFrom: '2024-01-01',
 })
 
-// If you need to iterate across all pages:
-const all = await client.fetchAllTransactions({
-  itemId: item.id,
-  pageSize: 500,
+// Manual pagination: follow the cursor until `next` is null
+let cursor = page.next
+while (cursor) {
+  const url = new URL(cursor)
+  const after = url.searchParams.get('after')!
+  const next = await client.fetchTransactionsCursor(account.id, {
+    dateFrom: '2024-01-01',
+    after,
+  })
+  // ...do something with next.results
+  cursor = next.next
+}
+
+// Or fetch all transactions in one call
+const all = await client.fetchAllTransactions(account.id, {
+  dateFrom: '2024-01-01',
 })
 ```
+
+> **Deprecation note:** the legacy page-based `fetchTransactions(accountId, options)` method (`GET /transactions`) is `@deprecated` and will be removed in a future major release. Migrate to `fetchTransactionsCursor` / `fetchAllTransactions` — the cursor endpoint is more stable for long lists and supports the full filter set (`dateTo`, `ids`, etc.).
 
 ### Webhooks
 

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -63,8 +63,8 @@ void (async function(): Promise<void> {
     console.log(
       `Account # ${account.id} has a balance of ${account.balance}, its number is ${account.number}`
     )
-    const transactions = await client.fetchTransactions(account.id)
-    transactions.results.forEach(tx => {
+    const transactions = await client.fetchAllTransactions(account.id)
+    transactions.forEach(tx => {
       console.log(
         `Transaction # ${tx.id} made at ${moment(tx.date).format('DD/MM/YYYY')}, description: ${
           tx.description
@@ -77,7 +77,7 @@ void (async function(): Promise<void> {
   if (accounts.results.length !== 0) {
     console.log(`Upadating transactions category to a random one`)
     const { id } = accounts.results[0]
-    const { results: transactions } = await client.fetchTransactions(id)
+    const transactions = await client.fetchAllTransactions(id)
 
     if (transactions.length !== 0) {
       // Select random transaction

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -128,35 +128,6 @@ describeIf('Integration Tests', () => {
   })
 
   describe('Transactions', () => {
-    it('fetchTransactions returns transactions', async () => {
-      expect(item).not.toBeNull()
-
-      const accounts = await client.fetchAccounts(item!.id)
-      expect(accounts.results.length).toBeGreaterThan(0)
-
-      const account = accounts.results[0]
-      const oneYearAgo = new Date()
-      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
-
-      const transactions = await client.fetchTransactions(account.id, {
-        from: oneYearAgo.toISOString().split('T')[0],
-        to: new Date().toISOString().split('T')[0],
-      })
-
-      expect(transactions).toBeDefined()
-      console.log(`Found ${transactions.total} transactions for account ${account.id}`)
-
-      if (transactions.results.length > 0) {
-        const tx = transactions.results[0]
-        console.log(`Transaction: ${tx.id}, Date: ${tx.date}, Amount: ${tx.amount}`)
-
-        // Verify we can fetch individual transaction
-        const fetchedTx = await client.fetchTransaction(tx.id)
-        expect(fetchedTx).toBeDefined()
-        expect(fetchedTx.id).toBe(tx.id)
-      }
-    })
-
     it('fetchTransactionsCursor returns cursor-paged transactions', async () => {
       expect(item).not.toBeNull()
 
@@ -177,6 +148,13 @@ describeIf('Integration Tests', () => {
       console.log(
         `fetchTransactionsCursor: ${page.results.length} results, next=${page.next ?? 'null'}`
       )
+
+      if (page.results.length > 0) {
+        const tx = page.results[0]
+        const fetchedTx = await client.fetchTransaction(tx.id)
+        expect(fetchedTx).toBeDefined()
+        expect(fetchedTx.id).toBe(tx.id)
+      }
     })
 
     it('fetchAllTransactions returns all transactions via cursor pagination', async () => {


### PR DESCRIPTION
## Summary
The `fetchTransactions` page-based method (`GET /transactions`) was already marked `@deprecated` in `client.ts` (PR #160) in favor of `fetchTransactionsCursor` / `fetchAllTransactions` (`GET /v2/transactions`). But several user-facing surfaces still referenced the deprecated method — undermining the deprecation. This sweep updates every remaining reference.

## Changes
- **`README.md`** — rewrites the Accounts & Transactions section around the cursor helpers. The previous snippet was also passing the wrong argument shape (`fetchTransactions({ itemId, ... })` instead of `fetchTransactions(accountId, options)`), so it would never have worked. Added an explicit deprecation note pointing readers at the cursor methods.
- **`example/src/index.ts`** — switches both call sites (transactions list and category update) to `fetchAllTransactions`.
- **`tests/integration.test.ts`** — drops the `fetchTransactions returns transactions` integration test (the existing cursor + `fetchAllTransactions` tests already cover the surface). Preserves `fetchTransaction(id)` by-id coverage by folding its assertions into the cursor test.

## What stays
- `client.ts` — the `fetchTransactions` method itself keeps its `@deprecated` JSDoc and remains exported. Removing it would be a breaking change and belongs in a future major release.
- `CLAUDE.md` — the SDK status section already documents the deprecation correctly.

## Test plan
- [x] `pnpm build` — clean.
- [x] `pnpm test` — 11/11 passing.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)