### PR TITLE
test: add nock-based unit coverage for PluggyPaymentsClient

### DIFF
--- a/tests/payments/automaticPix.test.ts
+++ b/tests/payments/automaticPix.test.ts
@@ -1,0 +1,103 @@
+import {
+  PaymentRequestAutomaticPix,
+  CreatePaymentRequestAutomaticPix,
+  AutomaticPixPayment,
+  AutomaticPixPaymentListResponse,
+  ScheduleAutomaticPixPaymentRequest,
+  RetryAutomaticPixPaymentRequest,
+} from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — automatic PIX', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createPaymentRequestPixAutomatico POSTs payments/requests/automatic-pix', async () => {
+    const payload = mockAs<CreatePaymentRequestAutomaticPix>({ amount: 100 })
+    const mock = nock(API_URL)
+      .post('/payments/requests/automatic-pix', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentRequestAutomaticPix>({ id: 'pix-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createPaymentRequestPixAutomatico(payload)
+
+    expect(result.id).toBe('pix-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('scheduleAutomaticPixPayment POSTs .../automatic-pix/schedule with payload', async () => {
+    const payload = mockAs<ScheduleAutomaticPixPaymentRequest>({ amount: 50 })
+    const mock = nock(API_URL)
+      .post('/payments/requests/auth-1/automatic-pix/schedule', payload as Record<string, unknown>)
+      .reply(200, mockAs<AutomaticPixPayment>({ id: 'apix-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.scheduleAutomaticPixPayment('auth-1', payload)
+
+    expect(result.id).toBe('apix-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('retryAutomaticPixPayment POSTs .../automatic-pix/schedules/:id/retry', async () => {
+    const payload = mockAs<RetryAutomaticPixPaymentRequest>({})
+    const mock = nock(API_URL)
+      .post(
+        '/payments/requests/req-1/automatic-pix/schedules/apix-1/retry',
+        payload as Record<string, unknown>
+      )
+      .reply(200, mockAs<AutomaticPixPayment>({ id: 'apix-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.retryAutomaticPixPayment('req-1', 'apix-1', payload)
+
+    expect(result.id).toBe('apix-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchAutomaticPixPayments GETs .../automatic-pix/schedules with filters', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/requests/auth-1/automatic-pix/schedules')
+      .query({ page: '1' })
+      .reply(200, mockAs<AutomaticPixPaymentListResponse>({ results: [] }))
+
+    const client = createPaymentsClient()
+    await client.fetchAutomaticPixPayments('auth-1', mockAs({ page: 1 }))
+
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchAutomaticPixPayment GETs .../automatic-pix/schedules/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/requests/req-1/automatic-pix/schedules/apix-1')
+      .reply(200, mockAs<AutomaticPixPayment>({ id: 'apix-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchAutomaticPixPayment('req-1', 'apix-1')
+
+    expect(result.id).toBe('apix-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('cancelAutomaticPixPayment POSTs .../automatic-pix/schedules/:id/cancel', async () => {
+    const mock = nock(API_URL)
+      .post('/payments/requests/req-1/automatic-pix/schedules/apix-1/cancel')
+      .reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.cancelAutomaticPixPayment('req-1', 'apix-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('cancelAutomaticPixAuthorization POSTs .../automatic-pix/cancel', async () => {
+    const mock = nock(API_URL)
+      .post('/payments/requests/req-1/automatic-pix/cancel')
+      .reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.cancelAutomaticPixAuthorization('req-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/bulkPayments.test.ts
+++ b/tests/payments/bulkPayments.test.ts
@@ -1,0 +1,58 @@
+import { BulkPayment, CreateBulkPaymentFields, PageResponse } from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — bulk payments', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createBulkPayment POSTs payments/bulk with payload', async () => {
+    const payload = mockAs<CreateBulkPaymentFields>({ smartAccountId: 'sa-1', payments: [] })
+    const mock = nock(API_URL)
+      .post('/payments/bulk', payload as Record<string, unknown>)
+      .reply(200, mockAs<BulkPayment>({ id: 'bulk-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createBulkPayment(payload)
+
+    expect(result.id).toBe('bulk-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchBulkPayment GETs payments/bulk/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/bulk/bulk-1')
+      .reply(200, mockAs<BulkPayment>({ id: 'bulk-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchBulkPayment('bulk-1')
+
+    expect(result.id).toBe('bulk-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchBulkPayments GETs payments/bulk', async () => {
+    const page: PageResponse<BulkPayment> = {
+      page: 1,
+      total: 0,
+      totalPages: 0,
+      results: [],
+    }
+    const mock = nock(API_URL).get('/payments/bulk').reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchBulkPayments()
+
+    expect(result.results).toEqual([])
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('deleteBulkPayment DELETEs payments/bulk/:id', async () => {
+    const mock = nock(API_URL).delete('/payments/bulk/bulk-1').reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.deleteBulkPayment('bulk-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/paymentCustomers.test.ts
+++ b/tests/payments/paymentCustomers.test.ts
@@ -1,0 +1,75 @@
+import {
+  PaymentCustomer,
+  CreatePaymentCustomer,
+  PageResponse,
+} from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — payment customers', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createPaymentCustomer POSTs payments/customers with payload', async () => {
+    const payload = mockAs<CreatePaymentCustomer>({ name: 'John', email: 'j@example.com' })
+    const mock = nock(API_URL)
+      .post('/payments/customers', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentCustomer>({ id: 'cust-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createPaymentCustomer(payload)
+
+    expect(result.id).toBe('cust-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentCustomer GETs payments/customers/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/customers/cust-1')
+      .reply(200, mockAs<PaymentCustomer>({ id: 'cust-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentCustomer('cust-1')
+
+    expect(result.id).toBe('cust-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentCustomers GETs payments/customers', async () => {
+    const page: PageResponse<PaymentCustomer> = {
+      page: 1,
+      total: 0,
+      totalPages: 0,
+      results: [],
+    }
+    const mock = nock(API_URL).get('/payments/customers').reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentCustomers()
+
+    expect(result.results).toEqual([])
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('updatePaymentCustomer PATCHes payments/customers/:id with payload', async () => {
+    const payload: Partial<CreatePaymentCustomer> = mockAs({ name: 'Jane' })
+    const mock = nock(API_URL)
+      .patch('/payments/customers/cust-1', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentCustomer>({ id: 'cust-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.updatePaymentCustomer('cust-1', payload)
+
+    expect(result.id).toBe('cust-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('deletePaymentCustomer DELETEs payments/customers/:id', async () => {
+    const mock = nock(API_URL).delete('/payments/customers/cust-1').reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.deletePaymentCustomer('cust-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/paymentInstitutions.test.ts
+++ b/tests/payments/paymentInstitutions.test.ts
@@ -1,0 +1,40 @@
+import { PaymentInstitution, PageResponse } from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — payment institutions', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('fetchPaymentInstitution GETs payments/recipients/institutions/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/recipients/institutions/inst-1')
+      .reply(200, mockAs<PaymentInstitution>({ id: 'inst-1', name: 'Bank' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentInstitution('inst-1')
+
+    expect(result.id).toBe('inst-1')
+    expect(result.name).toBe('Bank')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentInstitutions GETs payments/recipients/institutions and forwards name filter', async () => {
+    const page: PageResponse<PaymentInstitution> = {
+      page: 1,
+      total: 1,
+      totalPages: 1,
+      results: [mockAs<PaymentInstitution>({ id: 'inst-1', name: 'Itaú' })],
+    }
+    const mock = nock(API_URL)
+      .get('/payments/recipients/institutions')
+      .query({ name: 'Itaú' })
+      .reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentInstitutions({ name: 'Itaú' })
+
+    expect(result.results).toHaveLength(1)
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/paymentIntents.test.ts
+++ b/tests/payments/paymentIntents.test.ts
@@ -1,0 +1,52 @@
+import { PaymentIntent, CreatePaymentIntent, PageResponse } from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — payment intents', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createPaymentIntent POSTs payments/intents with payload', async () => {
+    const payload = mockAs<CreatePaymentIntent>({ paymentRequestId: 'req-1' })
+    const mock = nock(API_URL)
+      .post('/payments/intents', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentIntent>({ id: 'intent-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createPaymentIntent(payload)
+
+    expect(result.id).toBe('intent-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentIntent GETs payments/intents/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/intents/intent-1')
+      .reply(200, mockAs<PaymentIntent>({ id: 'intent-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentIntent('intent-1')
+
+    expect(result.id).toBe('intent-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentIntents GETs payments/intents with filters', async () => {
+    const page: PageResponse<PaymentIntent> = {
+      page: 1,
+      total: 1,
+      totalPages: 1,
+      results: [mockAs<PaymentIntent>({ id: 'intent-1' })],
+    }
+    const mock = nock(API_URL)
+      .get('/payments/intents')
+      .query({ page: '1', pageSize: '20' })
+      .reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentIntents({ page: 1, pageSize: 20 })
+
+    expect(result.results).toHaveLength(1)
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/paymentRecipients.test.ts
+++ b/tests/payments/paymentRecipients.test.ts
@@ -1,0 +1,76 @@
+import {
+  PaymentRecipient,
+  CreatePaymentRecipient,
+  UpdatePaymentRecipient,
+  PageResponse,
+} from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — payment recipients', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createPaymentRecipient POSTs payments/recipients with payload', async () => {
+    const payload = mockAs<CreatePaymentRecipient>({ name: 'Recipient' })
+    const mock = nock(API_URL)
+      .post('/payments/recipients', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentRecipient>({ id: 'rcp-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createPaymentRecipient(payload)
+
+    expect(result.id).toBe('rcp-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentRecipient GETs payments/recipients/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/recipients/rcp-1')
+      .reply(200, mockAs<PaymentRecipient>({ id: 'rcp-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentRecipient('rcp-1')
+
+    expect(result.id).toBe('rcp-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentRecipients GETs payments/recipients', async () => {
+    const page: PageResponse<PaymentRecipient> = {
+      page: 1,
+      total: 0,
+      totalPages: 0,
+      results: [],
+    }
+    const mock = nock(API_URL).get('/payments/recipients').reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentRecipients()
+
+    expect(result.results).toEqual([])
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('updatePaymentRecipient PATCHes payments/recipients/:id', async () => {
+    const payload = mockAs<UpdatePaymentRecipient>({ name: 'New name' })
+    const mock = nock(API_URL)
+      .patch('/payments/recipients/rcp-1', payload as Record<string, unknown>)
+      .reply(200, mockAs<PaymentRecipient>({ id: 'rcp-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.updatePaymentRecipient('rcp-1', payload)
+
+    expect(result.id).toBe('rcp-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('deletePaymentRecipient DELETEs payments/recipients/:id', async () => {
+    const mock = nock(API_URL).delete('/payments/recipients/rcp-1').reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.deletePaymentRecipient('rcp-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/paymentRequests.test.ts
+++ b/tests/payments/paymentRequests.test.ts
@@ -1,0 +1,63 @@
+import { PaymentRequest, CreatePaymentRequest, PageResponse } from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — payment requests', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createPaymentRequest POSTs payments/requests with payload', async () => {
+    const payload = mockAs<CreatePaymentRequest>({ amount: 1000, description: 'Test payment' })
+    const response = mockAs<PaymentRequest>({ id: 'req-1', amount: 1000, status: 'CREATED' })
+
+    const mock = nock(API_URL)
+      .post('/payments/requests', payload as Record<string, unknown>)
+      .reply(200, response)
+
+    const client = createPaymentsClient()
+    const result = await client.createPaymentRequest(payload)
+
+    expect(result.id).toBe('req-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentRequest GETs payments/requests/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/requests/req-1')
+      .reply(200, mockAs<PaymentRequest>({ id: 'req-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentRequest('req-1')
+
+    expect(result.id).toBe('req-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchPaymentRequests GETs payments/requests and forwards filters', async () => {
+    const page: PageResponse<PaymentRequest> = {
+      page: 1,
+      total: 1,
+      totalPages: 1,
+      results: [mockAs<PaymentRequest>({ id: 'req-1' })],
+    }
+    const mock = nock(API_URL)
+      .get('/payments/requests')
+      .query({ page: '2', pageSize: '50' })
+      .reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchPaymentRequests({ page: 2, pageSize: 50 })
+
+    expect(result.results).toHaveLength(1)
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('deletePaymentRequest DELETEs payments/requests/:id', async () => {
+    const mock = nock(API_URL).delete('/payments/requests/req-1').reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.deletePaymentRequest('req-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/scheduledPayments.test.ts
+++ b/tests/payments/scheduledPayments.test.ts
@@ -1,0 +1,60 @@
+import { SchedulePayment, PageResponse } from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — scheduled payments', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('fetchScheduledPayments GETs payments/requests/:id/schedules', async () => {
+    const page: PageResponse<SchedulePayment> = {
+      page: 1,
+      total: 1,
+      totalPages: 1,
+      results: [mockAs<SchedulePayment>({ id: 'sched-1' })],
+    }
+    const mock = nock(API_URL)
+      .get('/payments/requests/req-1/schedules')
+      .reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchScheduledPayments('req-1')
+
+    expect(result.results).toHaveLength(1)
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchScheduledPayment GETs payments/requests/:id/schedules/:scheduleId', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/requests/req-1/schedules/sched-1')
+      .reply(200, mockAs<SchedulePayment>({ id: 'sched-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchScheduledPayment('req-1', 'sched-1')
+
+    expect(result.id).toBe('sched-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('cancelScheduledPayment POSTs payments/requests/:id/schedules/:scheduleId/cancel', async () => {
+    const mock = nock(API_URL)
+      .post('/payments/requests/req-1/schedules/sched-1/cancel')
+      .reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.cancelScheduledPayment('req-1', 'sched-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('cancelScheduledPayments POSTs payments/requests/:id/schedules/cancel', async () => {
+    const mock = nock(API_URL)
+      .post('/payments/requests/req-1/schedules/cancel')
+      .reply(200, {})
+
+    const client = createPaymentsClient()
+    await client.cancelScheduledPayments('req-1')
+
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/smartAccounts.test.ts
+++ b/tests/payments/smartAccounts.test.ts
@@ -1,0 +1,66 @@
+import {
+  SmartAccount,
+  SmartAccountBalance,
+  CreateSmartAccount,
+  PageResponse,
+} from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — smart accounts', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('createSmartAccount POSTs payments/smart-accounts with payload', async () => {
+    const payload = mockAs<CreateSmartAccount>({ name: 'sa' })
+    const mock = nock(API_URL)
+      .post('/payments/smart-accounts', payload as Record<string, unknown>)
+      .reply(200, mockAs<SmartAccount>({ id: 'sa-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createSmartAccount(payload)
+
+    expect(result.id).toBe('sa-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchSmartAccount GETs payments/smart-accounts/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/smart-accounts/sa-1')
+      .reply(200, mockAs<SmartAccount>({ id: 'sa-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartAccount('sa-1')
+
+    expect(result.id).toBe('sa-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchSmartAccountBalance GETs payments/smart-accounts/:id/balance', async () => {
+    const mock = nock(API_URL)
+      .get('/payments/smart-accounts/sa-1/balance')
+      .reply(200, mockAs<SmartAccountBalance>({ amount: 12345 }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartAccountBalance('sa-1')
+
+    expect(result).toEqual(expect.objectContaining({ amount: 12345 }))
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchSmartAccounts GETs payments/smart-accounts', async () => {
+    const page: PageResponse<SmartAccount> = {
+      page: 1,
+      total: 0,
+      totalPages: 0,
+      results: [],
+    }
+    const mock = nock(API_URL).get('/payments/smart-accounts').reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartAccounts()
+
+    expect(result.results).toEqual([])
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/smartTransfers.test.ts
+++ b/tests/payments/smartTransfers.test.ts
@@ -1,0 +1,80 @@
+import {
+  SmartTransferPreauthorization,
+  CreateSmartTransferPreauthorization,
+  SmartTransferPayment,
+  CreateSmartTransferPayment,
+  PageResponse,
+} from '../../src/types'
+import { API_URL, createPaymentsClient, mockAs, nock } from './utils'
+
+describe('PluggyPaymentsClient — smart transfers', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('fetchSmartTransferPreauthorizations GETs smart-transfers/preauthorizations', async () => {
+    const page: PageResponse<SmartTransferPreauthorization> = {
+      page: 1,
+      total: 0,
+      totalPages: 0,
+      results: [],
+    }
+    const mock = nock(API_URL).get('/smart-transfers/preauthorizations').reply(200, page)
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartTransferPreauthorizations()
+
+    expect(result.results).toEqual([])
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('createSmartTransferPreauthorization POSTs smart-transfers/preauthorizations with payload', async () => {
+    const payload = mockAs<CreateSmartTransferPreauthorization>({ amount: 100 })
+    const mock = nock(API_URL)
+      .post('/smart-transfers/preauthorizations', payload as Record<string, unknown>)
+      .reply(200, mockAs<SmartTransferPreauthorization>({ id: 'pre-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createSmartTransferPreauthorization(payload)
+
+    expect(result.id).toBe('pre-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchSmartTransferPreauthorization GETs smart-transfers/preauthorizations/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/smart-transfers/preauthorizations/pre-1')
+      .reply(200, mockAs<SmartTransferPreauthorization>({ id: 'pre-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartTransferPreauthorization('pre-1')
+
+    expect(result.id).toBe('pre-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('createSmartTransferPayment POSTs smart-transfers/payments with payload', async () => {
+    const payload = mockAs<CreateSmartTransferPayment>({ preauthorizationId: 'pre-1' })
+    const mock = nock(API_URL)
+      .post('/smart-transfers/payments', payload as Record<string, unknown>)
+      .reply(200, mockAs<SmartTransferPayment>({ id: 'pay-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.createSmartTransferPayment(payload)
+
+    expect(result.id).toBe('pay-1')
+    expect(mock.isDone()).toBe(true)
+  })
+
+  it('fetchSmartTransferPayment GETs smart-transfers/payments/:id', async () => {
+    const mock = nock(API_URL)
+      .get('/smart-transfers/payments/pay-1')
+      .reply(200, mockAs<SmartTransferPayment>({ id: 'pay-1' }))
+
+    const client = createPaymentsClient()
+    const result = await client.fetchSmartTransferPayment('pay-1')
+
+    expect(result.id).toBe('pay-1')
+    expect(mock.isDone()).toBe(true)
+  })
+})

--- a/tests/payments/utils.ts
+++ b/tests/payments/utils.ts
@@ -1,0 +1,25 @@
+import nock from 'nock'
+import { PluggyPaymentsClient } from '../../src/paymentsClient'
+import { setupAuth } from '../utils'
+
+export const API_URL = process.env.PLUGGY_API_URL!
+
+/**
+ * Sets up the auth mock and returns a fresh PluggyPaymentsClient. Call
+ * from `beforeEach` after `nock.cleanAll()`.
+ */
+export function createPaymentsClient(): PluggyPaymentsClient {
+  setupAuth()
+  return new PluggyPaymentsClient({ clientId: '123', clientSecret: '456' })
+}
+
+/**
+ * Forces a value into a typed mock without spelling out every required
+ * field. Mirrors the `as unknown as T` pattern already used in
+ * tests/transactions.test.ts.
+ */
+export function mockAs<T>(partial: Record<string, unknown>): T {
+  return partial as unknown as T
+}
+
+export { nock }

--- a/tests/payments/utils.ts
+++ b/tests/payments/utils.ts
@@ -9,6 +9,12 @@ export const API_URL = process.env.PLUGGY_API_URL!
  * from `beforeEach` after `nock.cleanAll()`.
  */
 export function createPaymentsClient(): PluggyPaymentsClient {
+  // Block any unmocked real network call from the payments unit suite — a
+  // wrong path would otherwise hit the wire instead of failing the test.
+  // Scoped here (not in the shared setup) on purpose: the real-API
+  // integration suite never imports this module, and each npm test script
+  // runs in its own process, so live connections there stay enabled.
+  nock.disableNetConnect()
   setupAuth()
   return new PluggyPaymentsClient({ clientId: '123', clientSecret: '456' })
 }


### PR DESCRIPTION
## Summary
Adds `tests/payments/` — 10 spec files, 43 tests, one per public method of `PluggyPaymentsClient`. Mocks `/auth` + the target endpoint via `nock`, then asserts the SDK builds the right HTTP request (method, path, query, body) and parses the response.

## Why nock-only (no real-API integration)
We agreed off-PR: `PluggyPaymentsClient` talks to live PIX rails / BACEN. Even sandbox-like CRUD on customers and recipients can have side effects, and a real-API integration test that creates payment intents is unacceptable risk. The aggregation suite (`tests/integration/`, separate PR) runs against the real sandbox connector. Payments stays off the wire — these tests cover request/response shape without ever leaving the test process.

## Coverage (1:1 with public methods)
| Spec | Methods covered |
|------|-----------------|
| `paymentRequests.test.ts` | `createPaymentRequest`, `fetchPaymentRequest`, `fetchPaymentRequests`, `deletePaymentRequest` |
| `paymentIntents.test.ts` | `createPaymentIntent`, `fetchPaymentIntent`, `fetchPaymentIntents` |
| `paymentCustomers.test.ts` | `createPaymentCustomer`, `fetchPaymentCustomer`, `fetchPaymentCustomers`, `updatePaymentCustomer`, `deletePaymentCustomer` |
| `paymentRecipients.test.ts` | `createPaymentRecipient`, `fetchPaymentRecipient`, `fetchPaymentRecipients`, `updatePaymentRecipient`, `deletePaymentRecipient` |
| `paymentInstitutions.test.ts` | `fetchPaymentInstitution`, `fetchPaymentInstitutions` (with `name` filter) |
| `bulkPayments.test.ts` | `createBulkPayment`, `fetchBulkPayment`, `fetchBulkPayments`, `deleteBulkPayment` |
| `smartAccounts.test.ts` | `createSmartAccount`, `fetchSmartAccount`, `fetchSmartAccountBalance`, `fetchSmartAccounts` |
| `scheduledPayments.test.ts` | `fetchScheduledPayments`, `fetchScheduledPayment`, `cancelScheduledPayment`, `cancelScheduledPayments` |
| `automaticPix.test.ts` | `createPaymentRequestPixAutomatico`, `scheduleAutomaticPixPayment`, `retryAutomaticPixPayment`, `fetchAutomaticPixPayments`, `fetchAutomaticPixPayment`, `cancelAutomaticPixPayment`, `cancelAutomaticPixAuthorization` |
| `smartTransfers.test.ts` | `fetchSmartTransferPreauthorizations`, `createSmartTransferPreauthorization`, `fetchSmartTransferPreauthorization`, `createSmartTransferPayment`, `fetchSmartTransferPayment` |

## Helper
`tests/payments/utils.ts` factors shared boilerplate:
- `createPaymentsClient()` — wires `setupAuth()` and returns a fresh client.
- `mockAs<T>(partial)` — minimal-but-typed mock objects (same pattern as the existing `tests/transactions.test.ts`).

## Test plan
- [x] `pnpm test` — **54/54** passing (11 pre-existing + 43 new).
- [x] `pnpm build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)