### PR TITLE
feat: add operationTypeAdditionalInfo to Transaction

### DIFF
--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -163,6 +163,8 @@ export type Transaction = {
   categoryId: string | null
   /** Operation type of the transaction */
   operationType: string | null
+  /** Complementary, free-form information about the operation type, as provided by the institution. Only returned for Open Finance connectors */
+  operationTypeAdditionalInfo: string | null
   /** Provider ID of the transaction. Only returned for Open Finance connectors */
   providerId: string | null
   /** Date when the transaction was created in Pluggy */


### PR DESCRIPTION
Adds the `operationTypeAdditionalInfo` field to the Transaction model — a free-form complement to `operationType`, returned by the API for Open Finance connectors. It varies by institution (a sub-type code or a description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
