### PR TITLE
feat: add new Open Finance credit card fields

### DIFF
--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -99,11 +99,60 @@ export type ReservedBalanceRemuneration = {
   indexerAdditionalInfo: string | null
 }
 
+export const CREDIT_CARD_LIMIT_LINE_NAMES = [
+  'CREDITO_A_VISTA',
+  'CREDITO_PARCELADO',
+  'SAQUE_CREDITO_BRASIL',
+  'SAQUE_CREDITO_EXTERIOR',
+  'EMPRESTIMO_CARTAO_CONSIGNADO',
+  'OUTROS',
+] as const
+/**
+ * @typedef CreditCardLimitLineName
+ * Name of the credit limit line.
+ */
+export type CreditCardLimitLineName = typeof CREDIT_CARD_LIMIT_LINE_NAMES[number]
+
+export type DisaggregatedCreditLimit = {
+  /** Limit type (LIMITE_CREDITO_TOTAL or LIMITE_CREDITO_MODALIDADE_OPERACAO). */
+  creditLineLimitType: string
+  /** Indicates if the limit is consolidated or individual. */
+  consolidationType: string
+  /** Identification number of the credit card. */
+  identificationNumber: string
+  /** Indicates if the limit is flexible. */
+  isLimitFlexible: boolean
+  /** Used amount of the reported limit. */
+  usedAmount: number
+  /** Currency of the reported used amount. */
+  usedAmountCurrencyCode: CurrencyCode
+  /** Name of the credit limit line. */
+  lineName?: CreditCardLimitLineName
+  /** Additional information about the line name. Required when lineName is 'OUTROS'. */
+  lineNameAdditionalInfo?: string
+  /** Total amount of the granted limit. */
+  limitAmount?: number
+  /** Currency of the reported limit amount. */
+  limitAmountCurrencyCode?: CurrencyCode
+  /** Reason why the reported total limit amount is equal to zero. */
+  limitAmountReason?: string
+  /** Total limit amount customized by the customer through the institution's electronic channels. */
+  customizedLimitAmount?: number
+  /** Currency of the reported customized limit amount. */
+  customizedLimitAmountCurrencyCode?: CurrencyCode
+  /** Available amount of the reported limit. */
+  availableAmount?: number
+  /** Currency of the reported available amount. */
+  availableAmountCurrencyCode?: CurrencyCode
+}
+
 export type CreditData = {
   /** Credit card end user's level */
   level: string | null
   /** Credit card brand, ie. Mastercard, Visa */
   brand: string | null
+  /** Free text to specify the brand category when brand is marked as 'OTHER'. */
+  brandAdditionalInfo?: string
   /** Current balance close date */
   balanceCloseDate: Date | null
   /** Current balance due date */
@@ -122,4 +171,6 @@ export type CreditData = {
   status: 'ACTIVE' | 'BLOCKED' | 'CANCELLED' | null
   /** Credit card holder type. */
   holderType: 'MAIN' | 'ADDITIONAL' | null
+  /** Detailed credit limit information, broken down by credit line. Only returned for Open Finance connectors */
+  disaggregatedCreditLimits?: DisaggregatedCreditLimit[]
 }

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -85,6 +85,34 @@ export type TransactionMerchantData = {
   category?: string
 }
 
+export const CREDIT_CARD_ACCOUNT_FEE_TYPES = [
+  'ANNUAL_FEE',
+  'ATM_WITHDRAWAL_DOMESTIC',
+  'ATM_WITHDRAWAL_INTERNATIONAL',
+  'EMERGENCY_CREDIT_EVALUATION',
+  'CARD_REISSUE',
+  'BILL_PAYMENT_FEE',
+  'SMS',
+  'OTHER',
+] as const
+/**
+ * @typedef CreditCardAccountFeeType
+ * Type of fee charged on a credit card transaction.
+ */
+export type CreditCardAccountFeeType = typeof CREDIT_CARD_ACCOUNT_FEE_TYPES[number]
+
+export const CREDIT_CARD_ACCOUNT_OTHER_CREDIT_TYPES = [
+  'REVOLVING_CREDIT',
+  'BILL_INSTALLMENT',
+  'LOAN',
+  'OTHER',
+] as const
+/**
+ * @typedef CreditCardAccountOtherCreditType
+ * Other type of credit contracted on the card.
+ */
+export type CreditCardAccountOtherCreditType = typeof CREDIT_CARD_ACCOUNT_OTHER_CREDIT_TYPES[number]
+
 export type CreditCardMetadata = {
   /** The number of the installment */
   installmentNumber?: number
@@ -100,6 +128,14 @@ export type CreditCardMetadata = {
   billId?: string
   /** The masked card number */
   cardNumber?: string
+  /** Type of fee charged. Only returned for Open Finance connectors */
+  feeType?: CreditCardAccountFeeType
+  /** Additional information about the fee type. Required when feeType is 'OTHER'. Only returned for Open Finance connectors */
+  feeTypeAdditionalInfo?: string
+  /** Other type of credit contracted on the card. Only returned for Open Finance connectors */
+  otherCreditsType?: CreditCardAccountOtherCreditType
+  /** Additional information about the other credits type. Required when otherCreditsType is 'OTHER'. Only returned for Open Finance connectors */
+  otherCreditsAdditionalInfo?: string
 }
 
 export type TransactionFilters = PageFilters & {


### PR DESCRIPTION
## Summary

Pluggy's API now returns additional Open Finance credit-card fields. This PR models them in the SDK types so consumers can read them. All new fields are optional and additive.

**`CreditData`** (`src/types/account.ts`):
- `brandAdditionalInfo?: string` — free text specifying the brand category when `brand` is `OTHER`.
- `disaggregatedCreditLimits?: DisaggregatedCreditLimit[]` — detailed credit-limit breakdown (was already part of the API but unmodeled in the SDK).

**New `DisaggregatedCreditLimit` type** (`src/types/account.ts`):
- Full type modeled to match the API shape, plus the new fields:
  - `limitAmountReason?: string`
  - `customizedLimitAmount?: number`
  - `customizedLimitAmountCurrencyCode?: CurrencyCode`
  - `lineName?: CreditCardLimitLineName` (typed via the new union instead of a plain string)

**`CreditCardMetadata`** (`src/types/transaction.ts`):
- `feeType?: CreditCardAccountFeeType`
- `feeTypeAdditionalInfo?: string`
- `otherCreditsType?: CreditCardAccountOtherCreditType`
- `otherCreditsAdditionalInfo?: string`

**New enums / unions** (following the existing `as const` + `typeof[number]` idiom):
- `CreditCardLimitLineName`: `CREDITO_A_VISTA`, `CREDITO_PARCELADO`, `SAQUE_CREDITO_BRASIL`, `SAQUE_CREDITO_EXTERIOR`, `EMPRESTIMO_CARTAO_CONSIGNADO`, `OUTROS`
- `CreditCardAccountFeeType`: `ANNUAL_FEE`, `ATM_WITHDRAWAL_DOMESTIC`, `ATM_WITHDRAWAL_INTERNATIONAL`, `EMERGENCY_CREDIT_EVALUATION`, `CARD_REISSUE`, `BILL_PAYMENT_FEE`, `SMS`, `OTHER`
- `CreditCardAccountOtherCreditType`: `REVOLVING_CREDIT`, `BILL_INSTALLMENT`, `LOAN`, `OTHER`

## Test plan

- `pnpm install --frozen-lockfile` — OK
- `pnpm build` (`tsc -p tsconfig.build.json`) — passes; new fields/enums emitted to `dist/types/*.d.ts`
- `pnpm test` — 12 suites / 54 tests pass
- `pnpm exec eslint src/types/account.ts src/types/transaction.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)