### PR TITLE
docs: document the three-layer test structure in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,14 @@ pnpm lint
 pnpm audit:supply-chain
 ```
 
+### Test structure
+
+Three layers, by directory:
+
+- **Unit (default, offline)** — `tests/*.test.ts` (e.g. `transactions.test.ts`, `auth.test.ts`) and `tests/payments/*.test.ts`. Run by `pnpm test`, which ignores `tests/integration`. They mock HTTP with **nock** (`/auth` + the target endpoint) and assert the SDK builds the right request (method, path, query, body) and parses the response — no network, no credentials. The payments suite (`tests/payments/`) has one spec per public `PluggyPaymentsClient` method and calls `nock.disableNetConnect()` (scoped in `tests/payments/utils.ts`, **not** the shared `setupTests.ts`, so the integration suite keeps live connections) — a wrong path then fails hard instead of reaching the wire.
+- **Integration (real sandbox, opt-in)** — `tests/integration/*.test.ts`, run by `pnpm test:integration` (`--runInBand`). These hit the **real Pluggy API** against the sandbox connector (id `0`, `user-ok`/`password-ok`), create an item, poll until `UPDATED`, assert, then delete it defensively. Each spec owns its own item lifecycle (per-suite isolation), so wall time is ~30+ min. They **auto-skip** (`describe.skip`) when `PLUGGY_CLIENT_ID` / `PLUGGY_CLIENT_SECRET` are absent, so they're safe to run locally/in forks without creds. Credentials come from `.env.test` at the repo root (loaded by `tests/setupTests.ts`); CI runs them nightly + `workflow_dispatch`. See `tests/integration/README.md`.
+- **Shared** — `tests/utils.ts` (`setupAuth`, mock JWT) and `tests/setupTests.ts` (loads `.env.test`) back the unit suites; `tests/integration/helpers.ts` backs the integration suite.
+
 ### TypeScript & Build setup
 
 Two tsconfigs by design:


### PR DESCRIPTION
## What

Documents the test layout in `CLAUDE.md` — a new **Test structure** subsection under *Build and Test*. This session introduced two test layers that weren't described anywhere in the knowledge base:

- `tests/integration/` — real-sandbox integration suite (`pnpm test:integration`, #166)
- `tests/payments/` — nock-based unit coverage for `PluggyPaymentsClient` (#167)

## Why

The split is non-obvious and easy to trip over:
- `pnpm test` ignores `tests/integration`; the integration suite is opt-in via `pnpm test:integration`.
- Integration tests hit the **real API**, need `PLUGGY_CLIENT_ID`/`PLUGGY_CLIENT_SECRET` in `.env.test`, take ~30+ min, and **auto-skip** without creds.
- The payments unit suite scopes `nock.disableNetConnect()` in `tests/payments/utils.ts` (not the shared setup) so the integration suite keeps live connections — a subtlety worth recording.

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)