### PR TITLE
fix(deps): patch undici, js-yaml and brace-expansion advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,12 @@ overrides:
   lodash-es: 4.18.1
   braces: 3.0.3
   micromatch: 4.0.8
-  js-yaml: 4.2.0
-  brace-expansion@1: 1.1.14
-  brace-expansion@2: 2.0.3
-  brace-expansion@5: 5.0.6
+  js-yaml: 4.3.0
+  brace-expansion@1: 1.1.16
+  brace-expansion@2: 2.1.2
+  brace-expansion@5: 5.0.7
+  undici@6: 6.27.0
+  undici@7: 7.28.0
 
 importers:
 
@@ -1002,14 +1004,14 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1887,8 +1889,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2808,12 +2810,12 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -2963,7 +2965,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -3275,7 +3277,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -3643,7 +3645,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@6.0.3)
       tinyglobby: 0.2.16
-      undici: 7.25.0
+      undici: 7.28.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4062,16 +4064,16 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4238,7 +4240,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -5135,7 +5137,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5306,15 +5308,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimist@1.2.6: {}
 
@@ -5928,9 +5930,9 @@ snapshots:
   uglify-js@3.17.4:
     optional: true
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -162,13 +162,34 @@ overrides:
   #   GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in merge-key
   #     handling via repeated aliases, MODERATE) → patched in 4.2.0
   #     (no v4.1.2 was published; 4.2.0 is the fixed release).
-  js-yaml: '4.2.0'
+  #   GHSA-52cp-r559-cp3m (quadratic CPU via YAML merge-key chains,
+  #     HIGH) → patched in 4.3.0.
+  js-yaml: '4.3.0'
   # brace-expansion has three separate advisories — one per major
   # in active use. Version-scoped overrides keep each parent within
   # its expected semver range so 1.x consumers stay on 1.x, etc:
   #   GHSA-v6h2-p8h4-qcjw (LOW)      → patched in 1.1.12
   #   GHSA-f886-m6hf-6m8v (MODERATE) → patched in 1.1.13 / 2.0.3
   #   GHSA-jxxr-4gwj-5jf2 (MODERATE) → patched in 5.0.6
-  'brace-expansion@1': '1.1.14'
-  'brace-expansion@2': '2.0.3'
-  'brace-expansion@5': '5.0.6'
+  #   GHSA-3jxr-9vmj-r5cp (DoS via exponential-time expansion, HIGH)
+  #     → hits all three majors in their own ranges: patched in
+  #     1.1.16, 2.1.2 and 5.0.7 respectively.
+  'brace-expansion@1': '1.1.16'
+  'brace-expansion@2': '2.1.2'
+  'brace-expansion@5': '5.0.7'
+  # undici reaches us only through the release tooling — the
+  # @semantic-release/github client and @semantic-release/npm via
+  # @actions/core > @actions/http-client. Both majors are present in
+  # the tree and each has its own advisory set, so they are pinned
+  # separately to keep every parent inside its declared range:
+  #   GHSA-vxpw-j846-p89q (TLS certificate validation bypass, HIGH),
+  #   GHSA-p88m-4jfj-68fv (HTTP header injection, MODERATE),
+  #   GHSA-35p6-xmwp-9g52 (response queue poisoning, LOW) and
+  #   GHSA-g8m3-5g58-fq7m (Set-Cookie SameSite downgrade, LOW)
+  #     → all patched in 6.27.0.
+  #   GHSA-vmh5-mc38-953g (WebSocket client DoS, HIGH),
+  #   GHSA-hm92-r4w5-c3mj (WebSocket client DoS, HIGH) and
+  #   GHSA-pr7r-676h-xcf6 (cross-user information disclosure,
+  #     MODERATE) → all patched in 7.28.0.
+  'undici@6': '6.27.0'
+  'undici@7': '7.28.0'


### PR DESCRIPTION
## Summary

The strict supply-chain audit that gates the release job has been failing since 0.89.0, so **no publish has gone out** — the last two merges (`#175`, `#176`) are sitting on `master` unreleased. 15 vulnerabilities, all reaching us through dev-only tooling.

`pnpm audit --prod` is clean, so none of this affects the published package or anyone installing it. The gate was blocking releases over vulnerabilities in the release tooling itself.

New / raised overrides, all following the existing exact-version policy:

| Package | Was | Now | Advisories |
|---|---|---|---|
| `undici@6` | _(none)_ | `6.27.0` | GHSA-vxpw-j846-p89q, GHSA-p88m-4jfj-68fv, GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m |
| `undici@7` | _(none)_ | `7.28.0` | GHSA-vmh5-mc38-953g, GHSA-hm92-r4w5-c3mj, GHSA-pr7r-676h-xcf6 |
| `js-yaml` | `4.2.0` | `4.3.0` | GHSA-52cp-r559-cp3m |
| `brace-expansion@1` | `1.1.14` | `1.1.16` | GHSA-3jxr-9vmj-r5cp |
| `brace-expansion@2` | `2.0.3` | `2.1.2` | GHSA-3jxr-9vmj-r5cp |
| `brace-expansion@5` | `5.0.6` | `5.0.7` | GHSA-3jxr-9vmj-r5cp |

`undici` had no override before — it arrives through the `@semantic-release/github` client and through `@semantic-release/npm` via `@actions/core > @actions/http-client`. GHSA-3jxr-9vmj-r5cp applies to all three `brace-expansion` majors in their own ranges, not just 5.x.

All pinned versions are ≥14 days old, so they satisfy `minimumReleaseAge`.

## Test plan

- [x] `pnpm audit:supply-chain` — exits 0, "No known vulnerabilities found", 688 packages with verified registry signatures (was: 15 vulnerabilities, 4 low / 3 moderate / 8 high)
- [x] `pnpm audit --prod` — clean before and after, confirming no consumer impact
- [x] `pnpm test` — 56/56 pass
- [x] `pnpm build` clean
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm exec eslint .` clean